### PR TITLE
Add: odig.0.0.5

### DIFF
--- a/packages/odig/odig.0.0.5/opam
+++ b/packages/odig/odig.0.0.5/opam
@@ -1,34 +1,31 @@
 opam-version: "2.0"
-maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+synopsis: """Lookup documentation of installed OCaml packages"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 authors: ["The odig programmers"]
 homepage: "https://erratique.ch/software/odig"
 doc: "https://erratique.ch/software/odig/doc"
-license: ["ISC" "PT-Sans-fonts" "DejaVu-fonts" ]
 dev-repo: "git+https://erratique.ch/repos/odig.git"
 bug-reports: "https://github.com/b0-system/odig/issues"
-tags: [ "org:erratique" "org:b0-system" "build" "dev" "meta" "doc" "packaging" ]
-depends: [
-  "ocaml" {>= "4.05"}
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
-  "topkg" {build & >= "0.9.1"}
-  "cmdliner" {>= "1.0.0"}
-  "odoc" {>= "1.5.0"}
-  "b0" {= "0.0.1"}
-]
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
-
-synopsis: """Lookup documentation of installed OCaml packages"""
-description: """\
-
+license: ["ISC" "PT-Sans-fonts" "DejaVu-fonts"]
+tags: ["build" "dev" "doc" "meta" "packaging" "org:erratique"
+       "org:b0-system"]
+depends: ["ocaml" {>= "4.08"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "cmdliner" {>= "1.0.0"}
+          "odoc" {>= "1.5.0"}
+          "b0" {> "0.0.1" & <= "0.0.2"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/odig/releases/odig-0.0.5.tbz"
+  checksum: "sha512=a6f7e39d51ad2b544fd9d1f48d5c66bd44a0b6baf055a845a11dcc95f45096a3f9ec6600103a51c3f4a4da98a14a841c5c07992931ace0b6af6ef59bdb499cd9"}
+description: """
 odig is a command line tool to lookup documentation of installed OCaml
 packages. It shows package metadata, readmes, change logs, licenses,
 cross-referenced `odoc` API documentation and manuals.
 
 odig is distributed under the ISC license. The theme fonts have their
 own [licenses](LICENSE.md).
-"""
-url {
-archive: "https://erratique.ch/software/odig/releases/odig-0.0.5.tbz"
-checksum: "899a3f3d47b363fe670a0e5f79df2351"
-}
+
+Homepage: https://erratique.ch/software/odig"""


### PR DESCRIPTION
* Add: `odig.0.0.5` [home](https://erratique.ch/software/odig), [doc](https://erratique.ch/software/odig/doc), [issues](https://github.com/b0-system/odig/issues)  
  *Lookup documentation of installed OCaml packages*


---

#### `odig` v0.0.5 2020-03-11 La Forclaz (VS)

- Rework the `odoc-theme` command. The `set` command now
  unconditionally writes to `~/.conf/odig/odoc-theme` and sets the
  theme for generated doc (the `--default` flag no longer exists).
  The `default` command is renamed to `get`, a `--config` option is
  added to get the theme actually written in the configuration file.
- Add theme `odig.default`, `gruvbox` and `solarized`. These themes
  automatically switch between their corresponding light or dark 
  version acccording to the user browser preference ([#54](https://github.com/b0-system/odig/issues/54)).
- Make `odig.default` the default theme instead of `odoc.default`.
- Generate package index page even if some package fails ([#57](https://github.com/b0-system/odig/issues/57)).
- Hide anchoring links to screen readers on odig generated pages ([#55](https://github.com/b0-system/odig/issues/55)).
- Remove the `--trace` option of `odig odoc` and corresponding
  `ODIG_ODOC_TRACE` variable for generating a build log in Event trace
  format. See the `odig log` command. Use `odig log --trace-event` to
  generate what `--trace` did.
- For consistency with other tools, options `--{cache,doc,lib,share}dir` 
  are renamed to `--{cache,doc,lib,share}-dir` and corresponding 
  environment variable from `ODIG_{CACHE,DOC,LIB,SHARE}DIR` to
  `ODIG_{CACHE,DOC,LIB,SHARE}_DIR`.
- mld only packages: work around `odoc html-deps` bug ([#50](https://github.com/b0-system/odig/issues/50)).
- Package landing pages: fix cache invalidation. In particular opam metadata
  changes did not retrigger a rebuild.
- `gh-pages-amend` tool, add a `--cname-file` option to set
  the `CNAME` file in gh-pages.
- Fix `META` file ([#52](https://github.com/b0-system/odig/issues/52)). Thanks to Kye W. Shi for the report.
- Fix 4.08 `Pervasives` deprecation.
- Require OCaml >= 4.05.0

---

Use `b0 cmd -- .opam.publish odig.0.0.5` to update the pull request.